### PR TITLE
Use Email Host and Port from env variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,7 @@ JWT_SECRET="your-super-secret-key-change-in-production"
 EMAIL_HOST=smtp.gmail.com
 EMAIL_PORT=587
 EMAIL_SENDER=auth2@gmail.com
+EMAIL_USERNAME=auth2@gmail.com
 EMAIL_PASSWORD="your-super-secret-email-password"
 
 # Google OAuth Configuration

--- a/internals/config/config.go
+++ b/internals/config/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	EmailHost          string
 	EmailPort          string
 	EmailSender        string
+	EmailUsername      string
 	EmailPass          string
 	GoogleClientID     string
 	GoogleClientSecret string
@@ -41,6 +42,7 @@ func LoadConfig() *Config {
 		EmailHost:          os.Getenv("EMAIL_HOST"),
 		EmailPort:          os.Getenv("EMAIL_PORT"),
 		EmailSender:        os.Getenv("EMAIL_SENDER"),
+		EmailUsername:      os.Getenv("EMAIL_USERNAME"),
 		EmailPass:          os.Getenv("EMAIL_PASSWORD"),
 		GoogleClientID:     os.Getenv("GOOGLE_CLIENT_ID"),
 		GoogleClientSecret: os.Getenv("GOOGLE_CLIENT_SECRET"),

--- a/internals/utils/email.go
+++ b/internals/utils/email.go
@@ -12,6 +12,7 @@ func SendVerificationEmail(to string, token string, cfg *config.Config) error {
 	host := cfg.EmailHost
 	port := cfg.EmailPort
 	from := cfg.EmailSender
+	appUsername := cfg.EmailUsername
 	appPassword := cfg.EmailPass
 
 	subject := "Email Verification"
@@ -24,7 +25,7 @@ func SendVerificationEmail(to string, token string, cfg *config.Config) error {
 		</html>
 	`, cfg.AppPort, token)
 
-	auth := smtp.PlainAuth("", from, appPassword, host)
+	auth := smtp.PlainAuth("", appUsername, appPassword, host)
 
 	message := []byte(
 		"From: " + from + "\r\n" +
@@ -56,6 +57,7 @@ func SendPasswordResetEmail(to string, token string, cfg *config.Config) error {
 	host := cfg.EmailHost
 	port := cfg.EmailPort
 	from := cfg.EmailSender
+	appUsername := cfg.EmailUsername
 	appPassword := cfg.EmailPass
 
 	subject := "Password Reset"
@@ -68,7 +70,7 @@ func SendPasswordResetEmail(to string, token string, cfg *config.Config) error {
 		</html>
 	`, cfg.AppPort, token)
 
-	auth := smtp.PlainAuth("", from, appPassword, host)
+	auth := smtp.PlainAuth("", appUsername, appPassword, host)
 
 	message := []byte(
 		"From: " + from + "\r\n" +

--- a/internals/utils/email.go
+++ b/internals/utils/email.go
@@ -9,6 +9,8 @@ import (
 )
 
 func SendVerificationEmail(to string, token string, cfg *config.Config) error {
+	host := cfg.EmailHost
+	port := cfg.EmailPort
 	from := cfg.EmailSender
 	appPassword := cfg.EmailPass
 
@@ -22,7 +24,7 @@ func SendVerificationEmail(to string, token string, cfg *config.Config) error {
 		</html>
 	`, cfg.AppPort, token)
 
-	auth := smtp.PlainAuth("", from, appPassword, "smtp.gmail.com")
+	auth := smtp.PlainAuth("", from, appPassword, host)
 
 	message := []byte(
 		"From: " + from + "\r\n" +
@@ -34,7 +36,7 @@ func SendVerificationEmail(to string, token string, cfg *config.Config) error {
 	)
 
 	err := smtp.SendMail(
-		"smtp.gmail.com:587",
+		fmt.Sprintf("%s:%s", host, port),
 		auth,
 		from,
 		[]string{to},
@@ -51,6 +53,8 @@ func SendVerificationEmail(to string, token string, cfg *config.Config) error {
 }
 
 func SendPasswordResetEmail(to string, token string, cfg *config.Config) error {
+	host := cfg.EmailHost
+	port := cfg.EmailPort
 	from := cfg.EmailSender
 	appPassword := cfg.EmailPass
 
@@ -64,7 +68,7 @@ func SendPasswordResetEmail(to string, token string, cfg *config.Config) error {
 		</html>
 	`, cfg.AppPort, token)
 
-	auth := smtp.PlainAuth("", from, appPassword, "smtp.gmail.com")
+	auth := smtp.PlainAuth("", from, appPassword, host)
 
 	message := []byte(
 		"From: " + from + "\r\n" +
@@ -76,7 +80,7 @@ func SendPasswordResetEmail(to string, token string, cfg *config.Config) error {
 	)
 
 	err := smtp.SendMail(
-		"smtp.gmail.com:587",
+		fmt.Sprintf("%s:%s", host, port),
 		auth,
 		from,
 		[]string{to},


### PR DESCRIPTION
# Changelog

- Reads Email Host and Port from env file and uses them
- Differentiate between Email Username and Email Sender (helpful for some providers where API key is used as password and `api` is used as username, e.g., Mailtrap)

- Closes #3 