### PR TITLE
feat(oauth): add Facebook OAuth consent URL and handler

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -35,6 +35,7 @@ func main() {
 	router.HandleFunc("/auth/google/callback", handler.GoogleLogin).Methods("GET")
 	router.HandleFunc("/auth/github", handler.GithubOAuthConsentRedirect).Methods("GET")
 	router.HandleFunc("/auth/github/callback", handler.GithubLogin).Methods("GET")
+	router.HandleFunc("/auth/facebook", handler.FacebookOAuthConsentRedirect).Methods("GET")
 	router.HandleFunc("/auth/facebook/callback", handler.FacebookLogin).Methods("GET")
 	router.HandleFunc("/forget-password", handler.ForgotPassword).Methods("GET")
 	router.HandleFunc("/get-user", handler.GetUserById).Methods("GET")

--- a/internals/handlers/handlers.go
+++ b/internals/handlers/handlers.go
@@ -81,6 +81,10 @@ func (h *Handler) GithubOAuthConsentRedirect(w http.ResponseWriter, r *http.Requ
 	http.Redirect(w, r, services.GithubOAuthConsentURL(h.Config), http.StatusTemporaryRedirect)
 }
 
+func (h *Handler) FacebookOAuthConsentRedirect(w http.ResponseWriter, r *http.Request) {
+	http.Redirect(w, r, services.FacebookOAuthConsentURL(h.Config), http.StatusTemporaryRedirect)
+}
+
 func (h *Handler) GoogleLogin(w http.ResponseWriter, r *http.Request) {
 	code := r.URL.Query().Get("code")
 	if code == "" {

--- a/internals/services/oAuth.go
+++ b/internals/services/oAuth.go
@@ -59,6 +59,12 @@ func GithubOAuthConsentURL(cfg *config.Config) string {
 	return oauthConfig.AuthCodeURL("state")
 }
 
+func FacebookOAuthConsentURL(cfg *config.Config) string {
+	oauthConfig := GetFacebookOAuthConfig(cfg)
+
+	return oauthConfig.AuthCodeURL("state")
+}
+
 func GoogleLogin(cfg *config.Config, repository *db.Repository, code string) (string, error) {
 	oauthConfig := GetGoogleOAuthConfig(cfg)
 


### PR DESCRIPTION
# Description

This commit introduces support for Facebook OAuth by adding a new function `FacebookOAuthConsentURL` in the `services` package and a corresponding handler `FacebookOAuthConsentRedirect` in the `handlers` package. Additionally, the main router is updated to include the new Facebook OAuth endpoint.

- Closes #18 