### PR TITLE
refactor: change user ID type from string to int for consistency

### DIFF
--- a/internals/db/repository.go
+++ b/internals/db/repository.go
@@ -34,7 +34,7 @@ func (repo *Repository) CreateUser(user *models.User) error {
 	return tx.Commit()
 }
 
-func (repo *Repository) GetUserByID(id string) (*models.User, error) {
+func (repo *Repository) GetUserByID(id int) (*models.User, error) {
 	var user models.User
 	query := `SELECT id, email, password, is_verified, created_at, updated_at, google_id, github_id, facebook_id, microsoft_id, linkedin_id FROM users WHERE id=$1`
 	err := repo.DB.QueryRow(query, id).Scan(&user.ID, &user.Email, &user.Password, &user.IsVerified, &user.CreatedAt, &user.UpdatedAt, &user.GoogleID, &user.GithubID, &user.FacebookID, &user.MicrosoftID, &user.LinkedinID)
@@ -176,19 +176,6 @@ func (repo *Repository) GetUserByLinkedinID(linkedinID int64) (*models.User, err
 	var user models.User
 	query := `SELECT id, email, password, is_verified, created_at, updated_at, linkedin_id FROM users WHERE linkedin_id = $1`
 	err := repo.DB.QueryRow(query, linkedinID).Scan(&user.ID, &user.Email, &user.Password, &user.IsVerified, &user.CreatedAt, &user.UpdatedAt, &user.LinkedinID)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, nil
-		}
-		return nil, err
-	}
-	return &user, nil
-}
-
-func (repo *Repository) GetUserById(id int) (*models.User, error) {
-	var user models.User
-	query := `SELECT id, email, is_verified, created_at, updated_at, google_id, github_id, facebook_id FROM users WHERE id = $1`
-	err := repo.DB.QueryRow(query, id).Scan(&user.ID, &user.Email, &user.IsVerified, &user.CreatedAt, &user.UpdatedAt, &user.GoogleID, &user.GithubID, &user.FacebookID)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, nil

--- a/internals/handlers/handlers.go
+++ b/internals/handlers/handlers.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"html/template"
 	"net/http"
+	"strconv"
 
 	"github.com/Skythrill256/auth-service/internals/config"
 	"github.com/Skythrill256/auth-service/internals/db"
@@ -206,7 +207,12 @@ func (h *Handler) GetUserById(w http.ResponseWriter, r *http.Request) {
 	if id == "" {
 		http.Error(w, "Id is required", http.StatusBadRequest)
 	}
-	user, err := services.GetUserByID(id, h.Repository)
+	userId, err := strconv.Atoi(id)
+	if err != nil {
+		http.Error(w, "Invalid user ID", http.StatusBadRequest)
+		return
+	}
+	user, err := services.GetUserByID(userId, h.Repository)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/internals/services/auth.go
+++ b/internals/services/auth.go
@@ -67,7 +67,7 @@ func VerifyEmail(token string, repository *db.Repository, cfg *config.Config) er
 	return repository.VerifyUserEmail(email)
 }
 
-func GetUserByID(id string, repository *db.Repository) (*models.User, error) {
+func GetUserByID(id int, repository *db.Repository) (*models.User, error) {
 	user, err := repository.GetUserByID(id)
 	if err != nil {
 		return nil, err
@@ -79,7 +79,7 @@ func GetUserByID(id string, repository *db.Repository) (*models.User, error) {
 }
 
 func UpdateUserProfile(userID int, name, avatar, bio, phoneNumber string, repository *db.Repository) error {
-	user, err := repository.GetUserByID(fmt.Sprint(userID))
+	user, err := repository.GetUserByID(userID)
 	if err != nil {
 		fmt.Println(err)
 		return err


### PR DESCRIPTION
The user ID was previously handled as a string in some functions and as an int in others, leading to inconsistency and potential bugs. This commit changes the user ID type to int across all relevant functions, ensuring consistency and reducing the need for type conversion. The `GetUserByID` method in the repository was also cleaned up to remove a redundant duplicate function.

- Fixes #27 