### PR TITLE
feat(login-history): add endpoint to retrieve user login history

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -58,6 +58,11 @@ func main() {
 	extraInfoRouter.HandleFunc("", handler.UpdateUserExtraInfo).Methods("PUT")
 	extraInfoRouter.HandleFunc("", handler.DeleteUserExtraInfo).Methods("DELETE")
 
+	// Login History routes with authentication middleware
+	loginHistoryRouter := router.PathPrefix("/login-history").Subrouter()
+	loginHistoryRouter.Use(utils.AuthMiddleware(cfg.JWTSecret))
+	loginHistoryRouter.HandleFunc("", handler.GetLoginHistory).Methods("GET")
+
 	log.Println("Server is running on port", cfg.AppPort)
 	log.Fatal(http.ListenAndServe(":"+cfg.AppPort, router))
 }

--- a/internals/db/repository.go
+++ b/internals/db/repository.go
@@ -275,3 +275,26 @@ func (repo *Repository) DeleteUserExtraInfo(userID int, key string) error {
 	}
 	return nil
 }
+
+func (repo *Repository) GetUserLoginHistory(userID int) ([]models.LoginRecord, error) {
+	query := `SELECT id, user_id, ip_address, login_time, created_at FROM login_records 
+	         WHERE user_id = $1 ORDER BY login_time DESC`
+
+	rows, err := repo.DB.Query(query, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var records []models.LoginRecord
+	for rows.Next() {
+		var record models.LoginRecord
+		err := rows.Scan(&record.ID, &record.UserID, &record.IPAddress, &record.LoginTime, &record.CreatedAt)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, record)
+	}
+
+	return records, nil
+}

--- a/internals/handlers/handlers.go
+++ b/internals/handlers/handlers.go
@@ -501,3 +501,26 @@ func (h *Handler) DeleteUserExtraInfo(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(http.StatusNoContent)
 }
+
+func (h *Handler) GetLoginHistory(w http.ResponseWriter, r *http.Request) {
+	email, ok := utils.GetUserEmailFromContext(r.Context())
+	if !ok || email == "" {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	user, err := h.Repository.GetUserByEmail(email)
+	if err != nil {
+		http.Error(w, "Failed to get user", http.StatusInternalServerError)
+		return
+	}
+
+	loginRecords, err := h.Repository.GetUserLoginHistory(user.ID)
+	if err != nil {
+		http.Error(w, "Failed to get login history", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(loginRecords)
+}

--- a/internals/handlers/handlers.go
+++ b/internals/handlers/handlers.go
@@ -522,5 +522,8 @@ func (h *Handler) GetLoginHistory(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(loginRecords)
+	if err := json.NewEncoder(w).Encode(loginRecords); err != nil {
+		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+		return
+	}
 }


### PR DESCRIPTION
This commit introduces a new endpoint `/login-history` that allows authenticated users to retrieve their login history. The endpoint is protected by JWT authentication middleware and fetches data from the `login_records` table in the database. The handler processes the request, validates the user, and returns the login history in JSON format.

- Closes #34 