### PR TITLE
feat(oauth): add Microsoft OAuth consent URL and handler

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -32,17 +32,24 @@ func main() {
 	router.HandleFunc("/signup", handler.SignUpUser).Methods("POST")
 	router.HandleFunc("/login", handler.Login).Methods("POST")
 	router.HandleFunc("/verify-email", handler.VerifyEmail).Methods("GET")
+	router.HandleFunc("/forget-password", handler.ForgotPassword).Methods("GET")
+	router.HandleFunc("/reset-password", handler.ResetPassword).Methods("GET", "POST")
+
 	router.HandleFunc("/auth/google", handler.GoogleOAuthConsentRedirect).Methods("GET")
 	router.HandleFunc("/auth/google/callback", handler.GoogleLogin).Methods("GET")
+
 	router.HandleFunc("/auth/github", handler.GithubOAuthConsentRedirect).Methods("GET")
 	router.HandleFunc("/auth/github/callback", handler.GithubLogin).Methods("GET")
+
 	router.HandleFunc("/auth/facebook", handler.FacebookOAuthConsentRedirect).Methods("GET")
 	router.HandleFunc("/auth/facebook/callback", handler.FacebookLogin).Methods("GET")
+
+	router.HandleFunc("/auth/microsoft", handler.MicrosoftOAuthConsentRedirect).Methods("GET")
 	router.HandleFunc("/auth/microsoft/callback", handler.MicrosoftLogin).Methods("GET")
+
 	router.HandleFunc("/auth/linkedin/callback", handler.LinkedinLogin).Methods("GET")
-	router.HandleFunc("/forget-password", handler.ForgotPassword).Methods("GET")
+
 	router.HandleFunc("/get-user", handler.GetUserById).Methods("GET")
-	router.HandleFunc("/reset-password", handler.ResetPassword).Methods("GET", "POST")
 
 	// Profile management routes with authentication middleware
 	profileRouter := router.PathPrefix("/profile").Subrouter()

--- a/internals/handlers/handlers.go
+++ b/internals/handlers/handlers.go
@@ -98,6 +98,10 @@ func (h *Handler) FacebookOAuthConsentRedirect(w http.ResponseWriter, r *http.Re
 	http.Redirect(w, r, services.FacebookOAuthConsentURL(h.Config), http.StatusTemporaryRedirect)
 }
 
+func (h *Handler) MicrosoftOAuthConsentRedirect(w http.ResponseWriter, r *http.Request) {
+	http.Redirect(w, r, services.MicrosoftOAuthConsentURL(h.Config), http.StatusTemporaryRedirect)
+}
+
 func (h *Handler) GetProfile(w http.ResponseWriter, r *http.Request) {
 	email, ok := utils.GetUserEmailFromContext(r.Context())
 	if !ok || email == "" {

--- a/internals/services/oAuth.go
+++ b/internals/services/oAuth.go
@@ -88,6 +88,11 @@ func FacebookOAuthConsentURL(cfg *config.Config) string {
 	return oauthConfig.AuthCodeURL("state")
 }
 
+func MicrosoftOAuthConsentURL(cfg *config.Config) string {
+	oauthConfig := GetMicrosoftOAuthConfig(cfg)
+	return oauthConfig.AuthCodeURL("state")
+}
+
 func GoogleLogin(cfg *config.Config, repository *db.Repository, code string, ipAddress string) (string, error) {
 	oauthConfig := GetGoogleOAuthConfig(cfg)
 


### PR DESCRIPTION
Introduce Microsoft OAuth consent URL functionality to support Microsoft authentication. Add corresponding handler to redirect users to the Microsoft OAuth consent page.

- Closes #36 