### PR TITLE
feat(auth): add LinkedIn OAuth consent redirect endpoint

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -47,6 +47,7 @@ func main() {
 	router.HandleFunc("/auth/microsoft", handler.MicrosoftOAuthConsentRedirect).Methods("GET")
 	router.HandleFunc("/auth/microsoft/callback", handler.MicrosoftLogin).Methods("GET")
 
+	router.HandleFunc("/auth/linkedin", handler.LinkedinOAuthConsentRedirect).Methods("GET")
 	router.HandleFunc("/auth/linkedin/callback", handler.LinkedinLogin).Methods("GET")
 
 	router.HandleFunc("/get-user", handler.GetUserById).Methods("GET")

--- a/internals/handlers/handlers.go
+++ b/internals/handlers/handlers.go
@@ -102,6 +102,10 @@ func (h *Handler) MicrosoftOAuthConsentRedirect(w http.ResponseWriter, r *http.R
 	http.Redirect(w, r, services.MicrosoftOAuthConsentURL(h.Config), http.StatusTemporaryRedirect)
 }
 
+func (h *Handler) LinkedinOAuthConsentRedirect(w http.ResponseWriter, r *http.Request) {
+	http.Redirect(w, r, services.LinkedinOAuthConsentURL(h.Config), http.StatusTemporaryRedirect)
+}
+
 func (h *Handler) GetProfile(w http.ResponseWriter, r *http.Request) {
 	email, ok := utils.GetUserEmailFromContext(r.Context())
 	if !ok || email == "" {

--- a/internals/services/oAuth.go
+++ b/internals/services/oAuth.go
@@ -93,6 +93,12 @@ func MicrosoftOAuthConsentURL(cfg *config.Config) string {
 	return oauthConfig.AuthCodeURL("state")
 }
 
+func LinkedinOAuthConsentURL(cfg *config.Config) string {
+	oauthConfig := GetLinkedinOAuthConfig(cfg)
+
+	return oauthConfig.AuthCodeURL("state")
+}
+
 func GoogleLogin(cfg *config.Config, repository *db.Repository, code string, ipAddress string) (string, error) {
 	oauthConfig := GetGoogleOAuthConfig(cfg)
 


### PR DESCRIPTION
Introduce a new endpoint `/auth/linkedin` to handle LinkedIn OAuth consent redirects. This addition aligns with existing OAuth flows for other providers like Microsoft and Google, ensuring consistent authentication handling across platforms.

- Closes #38 