### PR TITLE
docs(issue_template): add issue template to standardize issue reporting

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -1,0 +1,70 @@
+<!--
+Thank you for taking the time to open an issue! Please fill out the relevant sections below.
+-->
+
+### Issue Type
+
+<!-- Select the type of issue by checking the appropriate line below. -->
+
+- [ ] Bug Report  
+- [ ] Feature Request  
+- [ ] Question / Discussion  
+- [ ] Documentation Improvement  
+
+---
+
+### Description
+
+<!-- Provide a clear and concise description of the issue or feature request. -->
+
+---
+
+### Steps to Reproduce (for bugs)
+
+1.  
+2.  
+3.  
+4.  
+
+<!-- Include code snippets or screenshots if helpful. -->
+
+---
+
+### Expected Behavior
+
+<!-- Describe what you expected to happen. -->
+
+---
+
+### Actual Behavior
+
+<!-- Describe what actually happened. -->
+
+---
+
+### Environment
+
+<!-- Fill out relevant information below. -->
+
+- OS:  
+- Go version:  
+
+---
+
+### Additional Context / Screenshots
+
+<!-- Add any other context, screenshots, or logs that might help. -->
+
+---
+
+### Checklist
+
+- [ ] I have searched existing issues to avoid duplicates.  
+- [ ] I have provided enough information for the maintainers to reproduce the issue or understand the request.
+
+### Open Source Event
+
+<!-- If you are participating in an open source event, please fill out the following information. -->
+
+- Event Name:
+- Event Site:


### PR DESCRIPTION
This commit introduces a new issue template to ensure consistent and detailed issue reporting. The template includes sections for issue type, description, steps to reproduce, expected/actual behavior, environment details, and additional context. This will help maintainers and contributors to better understand and address issues.

- Closes #41 