### PR TITLE
feat(auth): add Amazon OAuth Consent URL support for authentication

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -50,6 +50,9 @@ func main() {
 	router.HandleFunc("/auth/linkedin", handler.LinkedinOAuthConsentRedirect).Methods("GET")
 	router.HandleFunc("/auth/linkedin/callback", handler.LinkedinLogin).Methods("GET")
 
+	router.HandleFunc("/auth/amazon", handler.AmazonOAuthConsentURL).Methods("GET")
+	router.HandleFunc("/auth/amazon/callback", handler.AmazonLogin).Methods("GET")
+
 	router.HandleFunc("/get-user", handler.GetUserById).Methods("GET")
 
 	// Profile management routes with authentication middleware

--- a/internals/handlers/handlers.go
+++ b/internals/handlers/handlers.go
@@ -106,6 +106,10 @@ func (h *Handler) LinkedinOAuthConsentRedirect(w http.ResponseWriter, r *http.Re
 	http.Redirect(w, r, services.LinkedinOAuthConsentURL(h.Config), http.StatusTemporaryRedirect)
 }
 
+func (h *Handler) AmazonOAuthConsentURL(w http.ResponseWriter, r *http.Request) {
+	http.Redirect(w, r, services.AmazonOAuthConsentURL(h.Config), http.StatusTemporaryRedirect)
+}
+
 func (h *Handler) AmazonLogin(w http.ResponseWriter, r *http.Request) {
 	code := r.URL.Query().Get("code")
 	if code == "" {

--- a/internals/services/oAuth.go
+++ b/internals/services/oAuth.go
@@ -73,19 +73,16 @@ func GetLinkedinOAuthConfig(cfg *config.Config) *oauth2.Config {
 
 func GoogleOAuthConsentURL(cfg *config.Config) string {
 	oauthConfig := GetGoogleOAuthConfig(cfg)
-
 	return oauthConfig.AuthCodeURL("state")
 }
 
 func GithubOAuthConsentURL(cfg *config.Config) string {
 	oauthConfig := GetGithubOAuthConfig(cfg)
-
 	return oauthConfig.AuthCodeURL("state")
 }
 
 func FacebookOAuthConsentURL(cfg *config.Config) string {
 	oauthConfig := GetFacebookOAuthConfig(cfg)
-
 	return oauthConfig.AuthCodeURL("state")
 }
 
@@ -96,7 +93,11 @@ func MicrosoftOAuthConsentURL(cfg *config.Config) string {
 
 func LinkedinOAuthConsentURL(cfg *config.Config) string {
 	oauthConfig := GetLinkedinOAuthConfig(cfg)
+	return oauthConfig.AuthCodeURL("state")
+}
 
+func AmazonOAuthConsentURL(cfg *config.Config) string {
+	oauthConfig := GetAmazonOAuthConfig(cfg)
 	return oauthConfig.AuthCodeURL("state")
 }
 


### PR DESCRIPTION
This commit introduces Amazon OAuth Consent URL support by adding new handler functions and routes for Amazon authentication. The changes include the addition of `/auth/amazon` route, along with the corresponding handler methods `AmazonOAuthConsentURL`. The `AmazonOAuthConsentURL` function generates the OAuth consent URL for Amazon authentication, similar to existing OAuth providers.

- Closes #45 