### PR TITLE
ci(workflows): add auto-labeling for Apertre PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -53,3 +53,9 @@ Closes #
 
 <!-- Anything else the reviewer should know -->
 
+### Open Source Event
+
+<!-- If you are participating in an open source event, please fill out the following information. -->
+
+- Event Name:
+- Event Site:

--- a/.github/workflows/label-apertre.yml
+++ b/.github/workflows/label-apertre.yml
@@ -1,0 +1,34 @@
+name: Auto Label Apertre PRs
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  label-apertre:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Add label if "Apertre" or "Apertre 2.0" is mentioned
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prBody = context.payload.pull_request.body || "";
+            const issue_number = context.payload.pull_request.number;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+
+            const matches = prBody.match(/Apertre\s*2\.?0?|Apertre/i);
+
+            if (matches) {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number,
+                labels: ['apertre2.0']
+              });
+              console.log('Label "apertre2.0" added to PR #' + issue_number);
+            } else {
+              console.log('No Apertre mention found in PR body.');
+            }


### PR DESCRIPTION
### Description

Add a new GitHub workflow to automatically label pull requests that mention "Apertre" or "Apertre 2.0" in the PR body. This improves PR categorization and streamlines the review process for event-related contributions.

---

### Related Issues

<!-- Link to related issues, e.g. Fixes #123 or Closes #456 -->
Closes #47 

---

### Type of Change

<!-- Please check all relevant options -->

- [ ] 🐛 Bug fix  
- [x] ✨ New feature  
- [ ] 🧪 Tests  
- [x] 📚 Documentation update  
- [ ] ♻️ Refactoring  
- [ ] 🚀 Performance improvement  
- [ ] 🧹 Chore / Tooling  
- [ ] 🔒 Security fix  

---

### Checklist

- [x] I’ve updated documentation if needed  
- [x] I’ve followed the coding style of this project  
- [x] I’ve linked relevant issues  
- [x] I’ve verified that my changes don’t break existing features  


### Open Source Event

<!-- If you are participating in an open source event, please fill out the following information. -->

- Event Name: Apertre 2.0
- Event Site: https://s2apertre.resourcio.in/

