### PR TITLE
feat(auth): add Bitbucket OAuth consent URL handler

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -53,6 +53,7 @@ func main() {
 	router.HandleFunc("/auth/amazon", handler.AmazonOAuthConsentURL).Methods("GET")
 	router.HandleFunc("/auth/amazon/callback", handler.AmazonLogin).Methods("GET")
 
+	router.HandleFunc("/auth/bitbucket", handler.BitbucketOAuthConsentRedirect).Methods("GET")
 	router.HandleFunc("/auth/bitbucket/callback", handler.BitbucketLogin).Methods("GET")
 
 	router.HandleFunc("/get-user", handler.GetUserById).Methods("GET")

--- a/internals/handlers/handlers.go
+++ b/internals/handlers/handlers.go
@@ -110,6 +110,10 @@ func (h *Handler) AmazonOAuthConsentURL(w http.ResponseWriter, r *http.Request) 
 	http.Redirect(w, r, services.AmazonOAuthConsentURL(h.Config), http.StatusTemporaryRedirect)
 }
 
+func (h *Handler) BitbucketOAuthConsentRedirect(w http.ResponseWriter, r *http.Request) {
+	http.Redirect(w, r, services.BitbucketOAuthConsentURL(h.Config), http.StatusTemporaryRedirect)
+}
+
 func (h *Handler) AmazonLogin(w http.ResponseWriter, r *http.Request) {
 	code := r.URL.Query().Get("code")
 	if code == "" {

--- a/internals/services/oAuth.go
+++ b/internals/services/oAuth.go
@@ -101,6 +101,11 @@ func AmazonOAuthConsentURL(cfg *config.Config) string {
 	return oauthConfig.AuthCodeURL("state")
 }
 
+func BitbucketOAuthConsentURL(cfg *config.Config) string {
+	oauthConfig := GetBitbucketOAuthConfig(cfg)
+	return oauthConfig.AuthCodeURL("state")
+}
+
 func GoogleLogin(cfg *config.Config, repository *db.Repository, code string, ipAddress string) (string, error) {
 	oauthConfig := GetGoogleOAuthConfig(cfg)
 


### PR DESCRIPTION
### Description

This commit introduces a new handler for generating the Bitbucket OAuth consent URL, enabling users to initiate the OAuth flow with Bitbucket. The changes include adding the route, service function, and handler to support this feature.

---

### Related Issues

<!-- Link to related issues, e.g. Fixes #123 or Closes #456 -->
Closes #52 

---

### Type of Change

<!-- Please check all relevant options -->

- [ ] 🐛 Bug fix  
- [x] ✨ New feature  
- [ ] 🧪 Tests  
- [ ] 📚 Documentation update  
- [ ] ♻️ Refactoring  
- [ ] 🚀 Performance improvement  
- [ ] 🧹 Chore / Tooling  
- [ ] 🔒 Security fix  

---

### Checklist

- [x] I’ve followed the coding style of this project  
- [x] I’ve linked relevant issues  
- [x] I’ve verified that my changes don’t break existing features  

---

### Open Source Event

<!-- If you are participating in an open source event, please fill out the following information. -->

- Event Name: Apertre 2.0
- Event Site: https://s2apertre.resourcio.in/
