### PR TITLE
ci(workflows): simplify label-apertre workflow using actions/labeler

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,4 @@
+# Add 'apertre2.0' label to any PR that mentions Apertre in its description
+apertre2.0:
+  - '(?i).*apertre\s*2\.?0?.*'
+  - '(?i).*apertre.*'

--- a/.github/workflows/label-apertre.yml
+++ b/.github/workflows/label-apertre.yml
@@ -6,33 +6,13 @@ on:
 
 permissions:
   pull-requests: write
-  issues: write
+  contents: read
 
 jobs:
   label-apertre:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Add label if "Apertre" or "Apertre 2.0" is mentioned
-        uses: actions/github-script@v7
+      - uses: actions/labeler@v4
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const prBody = context.payload.pull_request.body || "";
-            const issue_number = context.payload.pull_request.number;
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-
-            const matches = prBody.match(/Apertre\s*2\.?0?|Apertre/i);
-
-            if (matches) {
-              await github.rest.issues.addLabels({
-                owner,
-                repo,
-                issue_number,
-                labels: ['apertre2.0']
-              });
-              console.log('Label "apertre2.0" added to PR #' + issue_number);
-            } else {
-              console.log('No Apertre mention found in PR body.');
-            }
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml


### PR DESCRIPTION
The previous implementation used a custom script to add labels based on PR descriptions. This change replaces it with the `actions/labeler` action, which simplifies the workflow and reduces maintenance overhead. The labeler configuration is now managed in a separate `.github/labeler.yml` file.

Extends #48 