### PR TITLE
feat(auth): add GitLab OAuth consent redirect endpoint

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -59,6 +59,7 @@ func main() {
 	router.HandleFunc("/auth/foursquare", handler.FoursquareOAuthConsentRedirect).Methods("GET")
 	router.HandleFunc("/auth/foursquare/callback", handler.FoursquareLogin).Methods("GET")
 
+	router.HandleFunc("/auth/gitlab", handler.GitLabOAuthConsentRedirect).Methods("GET")
 	router.HandleFunc("/auth/gitlab/callback", handler.GitLabLogin).Methods("GET")
 
 	router.HandleFunc("/get-user", handler.GetUserById).Methods("GET")

--- a/internals/handlers/handlers.go
+++ b/internals/handlers/handlers.go
@@ -118,6 +118,10 @@ func (h *Handler) FoursquareOAuthConsentRedirect(w http.ResponseWriter, r *http.
 	http.Redirect(w, r, services.FoursquareOAuthConsentURL(h.Config), http.StatusTemporaryRedirect)
 }
 
+func (h *Handler) GitLabOAuthConsentRedirect(w http.ResponseWriter, r *http.Request) {
+	http.Redirect(w, r, services.GitLabOAuthConsentURL(h.Config), http.StatusTemporaryRedirect)
+}
+
 func (h *Handler) AmazonLogin(w http.ResponseWriter, r *http.Request) {
 	code := r.URL.Query().Get("code")
 	if code == "" {

--- a/internals/services/oAuth.go
+++ b/internals/services/oAuth.go
@@ -154,6 +154,11 @@ func FoursquareOAuthConsentURL(cfg *config.Config) string {
 	return oauthConfig.AuthCodeURL("state")
 }
 
+func GitLabOAuthConsentURL(cfg *config.Config) string {
+	oauthConfig := GetGitLabOAuthConfig(cfg)
+	return oauthConfig.AuthCodeURL("state")
+}
+
 func FoursquareLogin(cfg *config.Config, repository *db.Repository, code string, ipAddress string) (string, error) {
 	oauthConfig := GetFoursquareOAuthConfig(cfg)
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please fill out the following information to help us review your pull request.
-->

### Description

This commit introduces a new endpoint `/auth/gitlab` to handle the OAuth consent redirect for GitLab authentication. The changes include adding the route in the main router, implementing the consent URL generation in the services, and creating the handler function to redirect users to GitLab's OAuth consent page.

---

### Related Issues

<!-- Link to related issues, e.g. Fixes #123 or Closes #456 -->
Closes #62 

---

### Type of Change

<!-- Please check all relevant options -->

- [ ] 🐛 Bug fix  
- [x] ✨ New feature  
- [ ] 🧪 Tests  
- [ ] 📚 Documentation update  
- [ ] ♻️ Refactoring  
- [ ] 🚀 Performance improvement  
- [ ] 🧹 Chore / Tooling  
- [ ] 🔒 Security fix  

---

### Checklist

- [x] I’ve followed the coding style of this project  
- [x] I’ve linked relevant issues  
- [x] I’ve verified that my changes don’t break existing features  

---

### Open Source Event

<!-- If you are participating in an open source event, please fill out the following information. -->

- Event Name: Apertre 2.0
- Event Site: https://s2apertre.resourcio.in/
