### PR TITLE
feat(auth): add Heroku OAuth consent redirect endpoint

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -62,6 +62,7 @@ func main() {
 	router.HandleFunc("/auth/gitlab", handler.GitLabOAuthConsentRedirect).Methods("GET")
 	router.HandleFunc("/auth/gitlab/callback", handler.GitLabLogin).Methods("GET")
 
+	router.HandleFunc("/auth/heroku", handler.HerokuOAuthConsentRedirect).Methods("GET")
 	router.HandleFunc("/auth/heroku/callback", handler.HerokuLogin).Methods("GET")
 
 	router.HandleFunc("/get-user", handler.GetUserById).Methods("GET")

--- a/internals/handlers/handlers.go
+++ b/internals/handlers/handlers.go
@@ -122,6 +122,10 @@ func (h *Handler) GitLabOAuthConsentRedirect(w http.ResponseWriter, r *http.Requ
 	http.Redirect(w, r, services.GitLabOAuthConsentURL(h.Config), http.StatusTemporaryRedirect)
 }
 
+func (h *Handler) HerokuOAuthConsentRedirect(w http.ResponseWriter, r *http.Request) {
+	http.Redirect(w, r, services.HerokuOAuthConsentURL(h.Config), http.StatusTemporaryRedirect)
+}
+
 func (h *Handler) AmazonLogin(w http.ResponseWriter, r *http.Request) {
 	code := r.URL.Query().Get("code")
 	if code == "" {

--- a/internals/services/oAuth.go
+++ b/internals/services/oAuth.go
@@ -170,6 +170,11 @@ func GitLabOAuthConsentURL(cfg *config.Config) string {
 	return oauthConfig.AuthCodeURL("state")
 }
 
+func HerokuOAuthConsentURL(cfg *config.Config) string {
+	oauthConfig := GetHerokuOAuthConfig(cfg)
+	return oauthConfig.AuthCodeURL("state")
+}
+
 func FoursquareLogin(cfg *config.Config, repository *db.Repository, code string, ipAddress string) (string, error) {
 	oauthConfig := GetFoursquareOAuthConfig(cfg)
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please fill out the following information to help us review your pull request.
-->

### Description

This commit introduces a new endpoint `/auth/heroku` to handle the OAuth consent redirect for Heroku authentication. The changes include adding the necessary handler and service functions to generate the OAuth consent URL for Heroku.

---

### Related Issues

<!-- Link to related issues, e.g. Fixes #123 or Closes #456 -->
Closes #67 

---

### Type of Change

<!-- Please check all relevant options -->

- [ ] 🐛 Bug fix  
- [x] ✨ New feature  
- [ ] 🧪 Tests  
- [ ] 📚 Documentation update  
- [ ] ♻️ Refactoring  
- [ ] 🚀 Performance improvement  
- [ ] 🧹 Chore / Tooling  
- [ ] 🔒 Security fix  

---

### Checklist

- [x] I’ve followed the coding style of this project  
- [x] I’ve linked relevant issues  
- [x] I’ve verified that my changes don’t break existing features  

---

### Open Source Event

<!-- If you are participating in an open source event, please fill out the following information. -->

- Event Name: Apertre 2.0
- Event Site: https://s2apertre.resourcio.in/
