### PR TITLE
feat(auth): add Instagram OAuth consent redirect handler

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -65,6 +65,7 @@ func main() {
 	router.HandleFunc("/auth/heroku", handler.HerokuOAuthConsentRedirect).Methods("GET")
 	router.HandleFunc("/auth/heroku/callback", handler.HerokuLogin).Methods("GET")
 
+	router.HandleFunc("/auth/instagram", handler.InstagramOAuthConsentRedirect).Methods("GET")
 	router.HandleFunc("/auth/instagram/callback", handler.InstagramLogin).Methods("GET")
 
 	router.HandleFunc("/get-user", handler.GetUserById).Methods("GET")

--- a/internals/handlers/handlers.go
+++ b/internals/handlers/handlers.go
@@ -98,6 +98,10 @@ func (h *Handler) FacebookOAuthConsentRedirect(w http.ResponseWriter, r *http.Re
 	http.Redirect(w, r, services.FacebookOAuthConsentURL(h.Config), http.StatusTemporaryRedirect)
 }
 
+func (h *Handler) InstagramOAuthConsentRedirect(w http.ResponseWriter, r *http.Request) {
+	http.Redirect(w, r, services.InstagramOAuthConsentURL(h.Config), http.StatusTemporaryRedirect)
+}
+
 func (h *Handler) MicrosoftOAuthConsentRedirect(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, services.MicrosoftOAuthConsentURL(h.Config), http.StatusTemporaryRedirect)
 }

--- a/internals/services/oAuth.go
+++ b/internals/services/oAuth.go
@@ -186,6 +186,11 @@ func HerokuOAuthConsentURL(cfg *config.Config) string {
 	return oauthConfig.AuthCodeURL("state")
 }
 
+func InstagramOAuthConsentURL(cfg *config.Config) string {
+	oauthConfig := GetInstagramOAuthConfig(cfg)
+	return oauthConfig.AuthCodeURL("state")
+}
+
 func FoursquareLogin(cfg *config.Config, repository *db.Repository, code string, ipAddress string) (string, error) {
 	oauthConfig := GetFoursquareOAuthConfig(cfg)
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please fill out the following information to help us review your pull request.
-->

### Description

This commit introduces a new handler for Instagram OAuth consent redirect, allowing users to initiate the OAuth flow for Instagram authentication. The changes include adding a new route in the main.go file, implementing the consent URL generation in the oAuth.go service, and creating the corresponding handler function in the handlers.go file.

---

### Related Issues

<!-- Link to related issues, e.g. Fixes #123 or Closes #456 -->
Closes #71 

---

### Type of Change

<!-- Please check all relevant options -->

- [ ] 🐛 Bug fix  
- [x] ✨ New feature  
- [ ] 🧪 Tests  
- [ ] 📚 Documentation update  
- [ ] ♻️ Refactoring  
- [ ] 🚀 Performance improvement  
- [ ] 🧹 Chore / Tooling  
- [ ] 🔒 Security fix  

---

### Checklist

- [x] I’ve followed the coding style of this project  
- [x] I’ve linked relevant issues  
- [x] I’ve verified that my changes don’t break existing features  

---

### Open Source Event

<!-- If you are participating in an open source event, please fill out the following information. -->

- Event Name: Apertre 2.0
- Event Site: https://s2apertre.resourcio.in/
